### PR TITLE
W-22352407 Update documentation to reflect the rebranding of MuleSoft MCP Server…

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -2,6 +2,6 @@
 * xref:index.adoc[Overview]
 * xref:mulesoft-mcp-server-release-notes.adoc[Release Notes]
 
-* xref:getting-started.adoc[Getting Started with MuleSoft MCP Server]
-* xref:using-mulesoft-mcp-server.adoc[Using MuleSoft MCP Server]
-* xref:reference-mcp-tools.adoc[MuleSoft MCP Server Tool Reference]
+* xref:getting-started.adoc[Getting Started with MuleSoft DX MCP Server]
+* xref:using-mulesoft-mcp-server.adoc[Using MuleSoft DX MCP Server]
+* xref:reference-mcp-tools.adoc[MuleSoft DX MCP Server Tool Reference]

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -1,14 +1,14 @@
-= Getting Started with MuleSoft MCP Server
+= Getting Started with MuleSoft DX MCP Server
 
-MuleSoft MCP Server enables AI-powered development assistants in your IDE to interact with Anypoint Platform, helping you manage APIs, applications, and platform resources directly from your coding environment. Install prerequisites, create a connected app with the scopes your tools require, and register the server in the IDE so assistants can call Anypoint Platform with your environments and identities. 
+MuleSoft DX MCP Server enables AI-powered development assistants in your IDE to interact with Anypoint Platform, helping you manage APIs, applications, and platform resources directly from your coding environment. Install prerequisites, create a connected app with the scopes your tools require, and register the server in the IDE so assistants can call Anypoint Platform with your environments and identities. 
 
 [IMPORTANT] 
 ====
-If you have Anypoint Code Builder or Connector Builder, MuleSoft MCP Server is already installed and configured in MuleSoft Vibes. For more information, see xref:anypoint-code-builder::api-ai-create-spec.adoc[] and xref:connector-builder::index.adoc[].
+If you have Anypoint Code Builder or Connector Builder, MuleSoft DX MCP Server is already installed and configured in MuleSoft Vibes. For more information, see xref:anypoint-code-builder::api-ai-create-spec.adoc[] and xref:connector-builder::index.adoc[].
 ====
 
 == Before You Begin
-Before you install and use MuleSoft MCP Server, ensure you have installed the following software:
+Before you install and use MuleSoft DX MCP Server, ensure you have installed the following software:
 
 * Anypoint Extension Pack version 1.10.0 or later
 * Git
@@ -21,11 +21,11 @@ You also need permissions or access to perform these tasks:
 
 == Create a Connected App
 
-Follow the steps in xref:access-management::creating-connected-apps-dev.adoc#create-connected-app-on-its-own-behalf[Create a Connected App That Acts on Its Own Behalf] to create a connected app. Note the Client ID and Client Secret, as you need these to configure MuleSoft MCP Server in your IDE.
+Follow the steps in xref:access-management::creating-connected-apps-dev.adoc#create-connected-app-on-its-own-behalf[Create a Connected App That Acts on Its Own Behalf] to create a connected app. Note the Client ID and Client Secret, as you need these to configure MuleSoft DX MCP Server in your IDE.
 
-Additionally, when prompted, add the following permission scopes. These scopes enable you to use specific MuleSoft MCP Server tools. Make sure that all business groups and relevant environments are selected for these scopes. 
+Additionally, when prompted, add the following permission scopes. These scopes enable you to use specific MuleSoft DX MCP Server tools. Make sure that all business groups and relevant environments are selected for these scopes. 
 
-Refer to the xref:reference-mcp-tools.adoc[] for details on all MuleSoft MCP Server tools. Only tools listed in these tables require specific permission scopes. 
+Refer to the xref:reference-mcp-tools.adoc[] for details on all MuleSoft DX MCP Server tools. Only tools listed in these tables require specific permission scopes. 
 
 === Anypoint Code Builder 
 [cols="1,2,1"]
@@ -156,13 +156,13 @@ a|
 * xref:reference-mcp-tools.adoc#get-reuse-metrics[get_reuse_metrics]
 |===
 
-== Install MuleSoft MCP Server
-Install MuleSoft MCP Server and then configure it in your IDE by adding the appropriate configuration snippet with your connected app credentials.
+== Install MuleSoft DX MCP Server
+Install MuleSoft DX MCP Server and then configure it in your IDE by adding the appropriate configuration snippet with your connected app credentials.
 
 To install with Node.js, run: `npm install -g mulesoft-mcp-server`.
 
 === Configure Your IDE
-You can configure Claude Desktop, Cursor, Windsurf, Zed, and other IDEs to work with the MuleSoft MCP Server. After you add the configuration, verify it by checking that the server has started
+You can configure Claude Desktop, Cursor, Windsurf, Zed, and other IDEs to work with the MuleSoft DX MCP Server. After you add the configuration, verify it by checking that the server has started
 in the MCP section of your IDE.
 
 For more information about Anypoint Platform regions, see xref:hosting-home::index.adoc#control-plane-hosting-options[Control Plane Hosting Options].

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,6 +1,6 @@
-= MuleSoft MCP Server Overview
+= MuleSoft DX MCP Server Overview
 
-MuleSoft MCP Server implements the Model Context Protocol (MCP) so AI assistants in your IDE can work with Anypoint Platform on your behalf through structured, permission-scoped tool calls. You state goals in natural language while the server automates work across API design, integration assets, deployments, governance, and operational insight. It integrates with MuleSoft Vibes in Anypoint Code Builder and Connector Builder, and with other MCP-aware editors such as Cursor, Windsurf, and VS Code.
+MuleSoft DX MCP Server implements the Model Context Protocol (MCP) so AI assistants in your IDE can work with Anypoint Platform on your behalf through structured, permission-scoped tool calls. You state goals in natural language while the server automates work across API design, integration assets, deployments, governance, and operational insight. It integrates with MuleSoft Vibes in Anypoint Code Builder and Connector Builder, and with other MCP-aware editors such as Cursor, Windsurf, and VS Code.
 
 Typical lifecycle areas you address through the tools include:
 
@@ -13,9 +13,9 @@ Typical lifecycle areas you address through the tools include:
 
 == Next Steps
 
-If you have Anypoint Code Builder desktop or Connector Builder, MuleSoft MCP Server is already included, configured, and ready to use. If you want to learn how to set up and configure MuleSoft MCP Server for your IDE, see xref:getting-started.adoc[].
+If you have Anypoint Code Builder desktop or Connector Builder, MuleSoft DX MCP Server is already included, configured, and ready to use. If you want to learn how to set up and configure MuleSoft DX MCP Server for your IDE, see xref:getting-started.adoc[].
 
-To start using MuleSoft MCP Server, see xref:using-mulesoft-mcp-server.adoc[] for some example prompts. For a complete list of tools for interacting with Anypoint Platform, see xref:reference-mcp-tools.adoc[]. 
+To start using MuleSoft DX MCP Server, see xref:using-mulesoft-mcp-server.adoc[] for some example prompts. For a complete list of tools for interacting with Anypoint Platform, see xref:reference-mcp-tools.adoc[]. 
 
 
 

--- a/modules/ROOT/pages/reference-mcp-tools.adoc
+++ b/modules/ROOT/pages/reference-mcp-tools.adoc
@@ -1,4 +1,4 @@
-= MuleSoft MCP Server Tool Reference
+= MuleSoft DX MCP Server Tool Reference
 
 MuleSoft DX MCP Server exposes tools for developing agent networks, building applications, creating connectors, managing deployments, governing APIs, and more. Each tool accepts specific parameters so assistants can automate tasks across Anypoint Platform APIs. Run them from your IDE to speed up delivery, tighten governance, and surface operational insight for your integrations.
 

--- a/modules/ROOT/pages/reference-mcp-tools.adoc
+++ b/modules/ROOT/pages/reference-mcp-tools.adoc
@@ -1,8 +1,8 @@
 = MuleSoft MCP Server Tool Reference
 
-MuleSoft MCP Server exposes tools for developing agent networks, building applications, creating connectors, managing deployments, governing APIs, and more. Each tool accepts specific parameters so assistants can automate tasks across Anypoint Platform APIs. Run them from your IDE to speed up delivery, tighten governance, and surface operational insight for your integrations.
+MuleSoft DX MCP Server exposes tools for developing agent networks, building applications, creating connectors, managing deployments, governing APIs, and more. Each tool accepts specific parameters so assistants can automate tasks across Anypoint Platform APIs. Run them from your IDE to speed up delivery, tighten governance, and surface operational insight for your integrations.
 
-NOTE: Some MuleSoft MCP Server tools are available only in the Anypoint Code Builder IDE or Connector Builder. 
+NOTE: Some MuleSoft DX MCP Server tools are available only in the Anypoint Code Builder IDE or Connector Builder.
 
 See xref:getting-started.adoc#create-a-connected-app[Create a Connected App] for information about which tools require specific permission scopes.
 

--- a/modules/ROOT/pages/using-mulesoft-mcp-server.adoc
+++ b/modules/ROOT/pages/using-mulesoft-mcp-server.adoc
@@ -1,6 +1,6 @@
-= Using MuleSoft MCP Server
+= Using MuleSoft DX MCP Server
 
-MuleSoft MCP Server integrates with MuleSoft Vibes so that you can build, deploy, and manage projects using natural language prompts. Whether you use Anypoint Code Builder, Cursor, Windsurf, or another MCP-compatible IDE, you keep the full Mule application lifecycle in your editor.
+MuleSoft DX MCP Server integrates with MuleSoft Vibes so that you can build, deploy, and manage projects using natural language prompts. Whether you use Anypoint Code Builder, Cursor, Windsurf, or another MCP-compatible IDE, you keep the full Mule application lifecycle in your editor.
 
 To learn more about MuleSoft Vibes, see xref:anypoint-code-builder::a4d-get-started.adoc[Get Started with MuleSoft Vibes].
 
@@ -14,7 +14,7 @@ Before you get started, make sure you meet these prerequisites.
 ** xref:anypoint-code-builder::start-acb.adoc[Set up and access the desktop IDE].  
 ** Set the xref:anypoint-code-builder::start-configure-permissions.adoc#permissions[required Anypoint Code Builder permissions], including the Mule Developer Generative AI User permission. 
 ** xref:access-management::enabling-agentforce.adoc[Enable Agentforce in Access Management].
-* If you're using Cursor, Windsurf, or any MCP-compatible IDE, make sure you set up and configure MuleSoft MCP Server for your IDE, including all permissions. See xref:getting-started.adoc[].
+* If you're using Cursor, Windsurf, or any MCP-compatible IDE, make sure you set up and configure MuleSoft DX MCP Server for your IDE, including all permissions. See xref:getting-started.adoc[].
 
 == Example: Create a Network Using MuleSoft Vibes
 


### PR DESCRIPTION
… to MuleSoft DX MCP Server

- Changed all instances of "MuleSoft MCP Server" to "MuleSoft DX MCP Server" across various documentation files.
- Updated section titles and content in 'Getting Started', 'Overview', 'Using', and 'Tool Reference' to ensure consistency with the new branding.
- Adjusted release notes to align with the new naming convention.