### PR TITLE
W-23515994 Rename Flex Gateway to Omni Gateway in customer-facing text

### DIFF
--- a/modules/ROOT/pages/reference-mcp-tools.adoc
+++ b/modules/ROOT/pages/reference-mcp-tools.adoc
@@ -3052,7 +3052,7 @@ Get an Omni Gateway policy example to help you configure your Rust source code. 
   "    }",
   "}"
 ],
-  "description": "Example Rust policy for manipulating request headers using the Flex Gateway Policy Development Kit (PDK)",
+  "description": "Example Rust policy for manipulating request headers using the Omni Gateway Policy Development Kit (PDK)",
   "dependencies": [
     "pdk = { version = \"0.1.0\" }",
     "tokio = { version = \"1.0\", features = [\"full\"] }"


### PR DESCRIPTION
## Summary
Renames customer-facing mentions of "Flex Gateway" to "Omni Gateway" in MCP tools reference.

## Changes
- Updated PDK example description from "Flex Gateway" to "Omni Gateway"

## Test plan
- [ ] Review changes to ensure all customer-facing text has been updated
- [ ] Verify documentation builds successfully
- [ ] Confirm no broken links or references

🤖 Generated with [Claude Code](https://claude.com/claude-code)